### PR TITLE
fix: allow units to be floating point numbers

### DIFF
--- a/syntaxes/vhs.tmLanguage.json
+++ b/syntaxes/vhs.tmLanguage.json
@@ -66,15 +66,11 @@
 				{
 					"name": "constant.numeric.vhs",
 					"match": "\\d*\\.?\\d+"
-				},
-				{
-					"name": "constant.numeric.vhs",
-					"match": "\\d+"
 				}
 			]
 		},
 		"units" : {
-			"match": "(\\d+)(ms|s)",
+			"match": "(\\d*\\.?\\d+)(ms|s)",
 			"captures": {
 				"1" : {
 					"patterns": [{


### PR DESCRIPTION
Unit numbers should allow floating point numbers, ex: `Sleep 2.5s`.
I also went ahead add removed the second `numbers` pattern because I'm pretty sure it is unnecessary - the first one covers everything already. I'm not too familiar with TextMate grammars though so if this is required I can undo that change.